### PR TITLE
Minim Challenge - DHCP packet analysis

### DIFF
--- a/src/unum/devtelemetry/devtelemetry_common.h
+++ b/src/unum/devtelemetry/devtelemetry_common.h
@@ -76,6 +76,15 @@ DT_TABLE_STATS_t *dt_dns_ip_tbl_stats(int reset);
 // Pass TRUE to reset the table (allows to get data and reset in one call)
 DT_TABLE_STATS_t *dt_dev_tbl_stats(int reset);
 
+// INCOMPLETE: (lmower 20190628)
+// Currently only a mechanism to be used as a callback for logging
+// DHCP offer packets. Should time allow, the same pattern of using
+// tables would be applied to DHCP information and report on things
+// such whether more than one DHCP server is issuing IPs on the lan
+// This will ultimately be defined like the other, e.g.
+// DT_TABLE_STATS_t *dt_dhcp_tbl_stats(int reset);
+void dt_dhcp_tbl_stats(void);
+
 // Returns pointer to the connections table stats.
 // Use from the tpcap callbacks only.
 // Subsequent calls override the data.
@@ -92,6 +101,13 @@ int dt_sender_start(void);
 
 // DNS info collector init function
 int dt_dns_collector_init(void);
+
+// INCOMPLETE: (lmower 20190628)
+// This function currently only logs to a file but should be modified
+// to collect and ship DHCP table information just as the other collect
+// functions do. Rename to dt_dhcp_collector_init() when complete.
+// DHCP info collector init function
+int dt_dhcp_init(void);
 
 // Device info collector init function
 // Returns: 0 - if successful

--- a/src/unum/devtelemetry/devtelemetry_common.mk
+++ b/src/unum/devtelemetry/devtelemetry_common.mk
@@ -19,9 +19,10 @@ CPPFLAGS += -I$(UNUM_PATH)/devtelemetry/$(MODEL)
 
 # Add code file(s)
 OBJECTS += \
-  ./devtelemetry/dt_collector.o  \
-  ./devtelemetry/dns_collector.o \
-  ./devtelemetry/dt_sender.o     \
+  ./devtelemetry/dt_collector.o   \
+  ./devtelemetry/dns_collector.o  \
+  ./devtelemetry/dhcp_collector.o \
+  ./devtelemetry/dt_sender.o      \
   ./devtelemetry/dt_stubs.o
 
 # Add subsystem initializer function

--- a/src/unum/devtelemetry/dhcp_collector.c
+++ b/src/unum/devtelemetry/dhcp_collector.c
@@ -1,0 +1,139 @@
+// device telemetry DHCP information collector
+
+#include "unum.h"
+
+/* Temporary, log to console or /var/log/dhcp.log from here */
+#undef LOG_DST
+#undef LOG_DBG_DST
+#define LOG_DST LOG_DST_DHCP
+// #define LOG_DBG_DST LOG_DST_CONSOLE
+
+// copycat from fp_dhcp.c and TPCAP_TEST_FP_JSON will need to be moved
+#ifdef DEBUG
+#define DPRINTF(args...) ((tpcap_test_param.int_val == TPCAP_TEST_FP_JSON) ? \
+                          (printf(args)) : 0)
+#else  // DEBUG
+#define DPRINTF(args...) /* Nothing */
+#endif // DEBUG
+
+// DHCP packet header (followed by options)
+struct dhcp_pkt {
+    u_int8_t  type;           // packet type
+    u_int8_t  haddrtype;      // type of hardware address (Ethernet, etc)
+    u_int8_t  haddrlen;       // length of hardware address
+    u_int8_t  hops;           // hops
+    u_int32_t sid;            // random transaction id number
+    u_int16_t sec;            // seconds used in timing
+    u_int16_t flags;          // flags
+    struct in_addr caddr;     // IP address of this machine (if available)
+    struct in_addr oaddr;     // IP address of this machine (if offered)
+    struct in_addr saddr;     // IP address of DHCP server
+    struct in_addr raddr;     // IP address of DHCP relay
+    unsigned char haddr[16];  // hardware address of this machine
+    char sname[64];           // DHCP server name
+    char file[128];           // boot file name
+    char cookie[4];           // cookie 0x63,0x82,0x53,0x63 for DHCP
+    unsigned char options[];  // variable length options (up to 308 bytes)
+} __attribute__((packed));
+
+// Forward declarations
+static void dhcp_offr_cb(TPCAP_IF_t *tpif,
+                           PKT_PROC_ENTRY_t *pe,
+                           struct tpacket2_hdr *thdr,
+                           struct iphdr *iph);
+
+// DHCP offer packet processing entry
+static PKT_PROC_ENTRY_t dt_dhcp_offr_pkt_proc = {
+    0,
+    {},
+    0,
+    {},
+    PKT_MATCH_TCPUDP_P1_SRC|PKT_MATCH_TCPUDP_P2_DST|PKT_MATCH_TCPUDP_UDP_ONLY,
+    { .p1 = 67, .p2 = 68 },
+    NULL, dhcp_offr_cb, NULL, NULL,
+    "UDP from port 67 to 68, DHCP offer"
+};
+
+// INCOMPLETE: (lmower 20190628)
+// DHCP offer packet callback added to packet processing entry
+// dt_dhcp_offr_pkt_proc for UDP packets originating from port 67 and destined
+// for port 68. This callback is currently logging to a file which is a big
+// 'no, no' and should be augmented upon the state full implementation of
+// collecting and processing DHCP information.
+static void dhcp_offr_cb(TPCAP_IF_t *tpif,
+                        PKT_PROC_ENTRY_t *pe,
+                        struct tpacket2_hdr *thdr,
+                        struct iphdr *iph)
+{
+    // No use for ethhdr at the moment but we will want this when
+    // moving information to the DHCP table.
+    // struct ethhdr *ehdr = (struct ethhdr *)((void *)thdr + thdr->tp_mac);
+    struct udphdr *udph = ((void *)iph) + sizeof(struct iphdr);
+    struct dhcp_pkt *dhdr = ((void *)udph) + sizeof(struct udphdr);
+
+    // copycat from fp_dhcp.c - dhcp_rcv_cb
+    int remains = thdr->tp_snaplen;
+    remains -= (thdr->tp_net - thdr->tp_mac) +
+               sizeof(struct iphdr) + sizeof(struct udphdr);
+    if(remains < sizeof(struct dhcp_pkt) + 1) {
+        log("%s: DEBUG - incomplete DHCP header, %d bytes remains, need %d\n",
+                     __func__, remains, sizeof(struct dhcp_pkt) + 1);
+        // DPRINTF("%s: incomplete DHCP header, %d bytes remains, need %d\n",
+        //           __func__, remains, sizeof(struct dhcp_pkt) + 1);
+        return;
+    }
+
+    // Only interested in DHCP offer packets
+    if(dhdr->type != 2) {
+        return;
+    }
+
+    // Verify DHCP cookie
+    if(memcmp("\x63\x82\x53\x63", dhdr->cookie, 4) != 0) {
+        log("%s: DEBUG - Offer pkt callback fail on magic cookie\n", __func__);
+        // DPRINTF("%s: invalid DHCP packet cookie %02x,%02x,%02x,%02x\n",
+        //        __func__, (unsigned char)dhdr->cookie[0],
+        //        (unsigned char)dhdr->cookie[1],
+        //        (unsigned char)dhdr->cookie[2],
+        //        (unsigned char)dhdr->cookie[3]);
+        return;
+    }
+
+    char oip_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &(dhdr->oaddr), oip_str, INET_ADDRSTRLEN);
+    char sip_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &(dhdr->saddr), sip_str, INET_ADDRSTRLEN);
+
+    log("%s: DEBUG - Offer pkt type: %u \n", __func__, dhdr->type);
+    log("%s: DEBUG - Offer pkt oaddr: %s \n", __func__, oip_str);
+    log("%s: DEBUG - Offer pkt saddr: %s \n", __func__, sip_str);
+    log("%s: DEBUG - Offer pkt proc entry desc: %s \n", __func__, pe->desc);
+
+    return;
+}
+
+
+int dt_dhcp_init(void)
+{
+    PKT_PROC_ENTRY_t *pe;
+
+    // Add the collector packet processing entries.
+    pe = &dt_dhcp_offr_pkt_proc;
+    if(tpcap_add_proc_entry(pe) != 0)
+    {
+        log("%s: tpcap_add_proc_entry() failed for: %s\n",
+            __func__, pe->desc);
+        return -1;
+    }
+
+    return 0;
+}
+
+// INCOMPLETE: (lmower 20190628)
+// Currently, the function dt_dhcp_tbl_stats() does nothing and has a signature
+// does not return a DT_TABLE_STATS_t see devtelemetry_common.h comment for more
+// information.
+// void dt_dhcp_tbls_test(void)
+// {    
+//     dt_dhcp_tbl_stats();
+// };

--- a/src/unum/devtelemetry/dt_collector.c
+++ b/src/unum/devtelemetry/dt_collector.c
@@ -784,6 +784,22 @@ int dt_main_collector_init(void)
 // with the next set of data.
 int devtelemetry_init(int level)
 {
+
+    // INCOMPLETE: (lmower 20199628)
+    // For the moment, this merely adds a PKT_PROC_ENTRY_t with a filter to
+    // examine UDP packets originating from port 67 destined for port 68 e.g.
+    // DHCP offer packets. Currently logs to a file at /var/log/dhcp.log for
+    // purposes of debugging but this should not be done during implementation
+    // and instead should parse relevant packet information into DT_DHCP_t
+    // which currently resides as FP_DHCP_t and should be moved.
+    // TODO:
+    // - Move FP_DHCP_t to DT_DHCP_t
+    // - Parse offer packet info into table
+    // - Rename dt_dhcp_init to dt_dhcp_collector_init
+    //   and move into init level telemetry block below
+    // Add DHCP offer packet process entry
+    dt_dhcp_init();
+
     if(level == INIT_LEVEL_DEVTELEMETRY)
     {
         // Initialize the device info collector

--- a/src/unum/devtelemetry/dt_collector.c
+++ b/src/unum/devtelemetry/dt_collector.c
@@ -679,6 +679,13 @@ static void stats_ready_cb(TPCAP_IF_STATS_t *st)
         // Reset main telemetry tables
         dt_reset_dev_tables();
 
+        // TODO: (lmower 20190628)
+        // Upon the implementation of collecting DHCP information
+        // via tables (commit a0618c4 for reference) uncomment this
+        // to include the DHCP table during resets.
+        // Reset DHCP tables
+        // dt_reset_dhcp_tables();
+
         // Reset fingerprinting tables (since we send them with
         // the devices telemetry have to do it here)
         fp_reset_tables();

--- a/src/unum/log/linux_generic/log_platform.c
+++ b/src/unum/log/linux_generic/log_platform.c
@@ -32,6 +32,9 @@ LOG_CONFIG_t log_cfg[] = {
 [LOG_DST_MONITOR] = {LOG_FLAG_FILE | LOG_FLAG_MUTEX | LOG_FLAG_INIT_MSG,
                      UTIL_MUTEX_INITIALIZER,
                      LOG_PATH_PREFIX "/monitor.log", 32*1024, 48*1024, 1},
+[LOG_DST_DHCP   ] = {LOG_FLAG_FILE | LOG_FLAG_MUTEX | LOG_FLAG_INIT_MSG,
+                     UTIL_MUTEX_INITIALIZER,
+                     LOG_PATH_PREFIX "/dhcp.log", 32*1024, 48*1024, 1},
 #ifdef DEBUG
 [LOG_DST_DEBUG  ] = {LOG_FLAG_FILE | LOG_FLAG_MUTEX | LOG_FLAG_INIT_MSG,
                      UTIL_MUTEX_INITIALIZER,

--- a/src/unum/log/log_common.h
+++ b/src/unum/log/log_common.h
@@ -41,6 +41,7 @@ typedef enum {
     LOG_DST_UNUM,    // generic agent logging to a file
     LOG_DST_HTTP,    // HTTP req/rsp logging to a file
     LOG_DST_MONITOR, // monitor process logging to a file
+    LOG_DST_DHCP,    // DHCP logging output
 #ifdef FW_UPDATER_OPMODE
     LOG_DST_UPDATE,  // firmware updater process, file
     LOG_DST_UPDATE_MONITOR, // updater monitor, file

--- a/src/unum/tpcap/tpcap.c
+++ b/src/unum/tpcap/tpcap.c
@@ -673,6 +673,10 @@ int tpcap_test(int test_mode)
                    __func__);
             return -2;
         }
+
+        // TODO: (lmower 20190628)
+        // Add test case for dt_dhcp_init()
+
         // For the dev telemetry main table tests we now need to add
         // festats (IP fast forwarding engine stats) subsystem init.
         // It's only available for some subsystems.


### PR DESCRIPTION
### Issues Addressed:
See problem statement and general challenge feedback, [here](https://gist.github.com/lowellmower/bc3a55b6461a164737db09982d82e6b4).

### Proposed Changes
Introduce logging of DHCP offer packets to a file `dhcp.log` under `/var/log/`

- [x] Capture DHCP offer packets
- [x] Log to stdout or file
- [ ] Detect if there is more than one DHCP server on the LAN
- [x] Move functionality to more appropriate space

### Validation
Build on Debian (stretch) VM ([see build repo here](https://github.com/lowellmower/unum-dev-env)):
```
# in openWrt directory on VM
[debian]$: make UNUM_DEBUG=1 MODEL=openwrt_generic V=s package/unum/compile
```
SCP to device:
```
# still on VM
[debian]$: scp unum_2019.2.0_arm_cortex-a7_neon-vfpv4.ipk root@192.168.11.1:/tmp/
root@192.168.11.1's password:
```
SSH to device, install, and tail log:
```
[debian]$: ssh root@192.168.11.1
root@192.168.11.1's password: 
[root@MINIM]$: opkg install --force-reinstall /tmp/unum_2019.2.0_arm_cortex-a7_neon-vfpv4.ipk
Removing package unum from root...
Installing unum (2019.2.0) to root...
Configuring unum.
No unum process instance found for: monitor
No unum process instance found for: agent
[root@MINIM]$: tail -f /var/log/dhcp.log

```
Renew the DHCP lease on a device connected to one of the wireless networks and examine logs:
```
[root@MINIM]$: tail -f /var/log/dhcp.log
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt type: 2 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt oaddr: 192.168.11.188 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt saddr: 192.168.11.1 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt proc entry desc: UDP from port 67 to 68, DHCP offer 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt type: 2 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt oaddr: 192.168.11.188 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt saddr: 192.168.11.1 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt proc entry desc: UDP from port 67 to 68, DHCP offer 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt type: 2 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt oaddr: 192.168.11.188 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt saddr: 192.168.11.1 
6691 2019.06.28 23:11:22 dhcp_offr_cb: DEBUG - Offer pkt proc entry desc: UDP from port 67 to 68, DHCP offer 
```